### PR TITLE
allow user to specify how long to wait for tingle reboot

### DIFF
--- a/lib/tingle/reboot
+++ b/lib/tingle/reboot
@@ -6,18 +6,23 @@ set -e
 
 usage() {
     cat - >&2 <<EOF
-Usage: tingle reboot
+Usage: tingle reboot [min]
 EOF
     exit_clean 2
 }
 
 execd /etc/tingle/hooks/pre-reboot.d
 
-MESSAGE="This system will reboot in ten minutes for a software update.
+min_to_reboot=$1
+if [ "x$min_to_reboot" = "x" ]; then
+  min_to_reboot=10
+fi
+
+MESSAGE="This system will reboot in $min_to_reboot minutes for a software update.
 
 Please save all open work and log out."
 
-reboot-politely 10 "$MESSAGE"
+reboot-politely $min_to_reboot "$MESSAGE"
 
 # These hooks must not take longer than ten minutes to run (for what I 
 # hope are obvious reasons).

--- a/ronn/tingle-reboot.8.md
+++ b/ronn/tingle-reboot.8.md
@@ -6,7 +6,7 @@ Part of the tingle(8) suite.
 
 ## SYNOPSIS
 
-`tingle` `reboot`
+`tingle` `reboot` `[min]`
 
 
 ## DESCRIPTION
@@ -29,6 +29,8 @@ appropriate:
 Execution order will correspond to the lexical sort order of script file 
 names.  The first hook script failure will trigger an immediate abort.
 
+You can supply an optional argument `min`, which is the number of minutes to
+wait until a reboot. If not supplied it defaults to 10 minutes.
 
 ## RETURN VALUES
 

--- a/ronn/tingle.8.md
+++ b/ronn/tingle.8.md
@@ -4,7 +4,7 @@ tingle(8) - (n): a thin patch
 
 ## SYNOPSIS
 
-`tingle` `check` | `warm` | `apply` | `reboot`
+`tingle` `check` | `warm` | `apply` | `reboot` `[min]`
 
 
 ## DESCRIPTION

--- a/sbin/tingle
+++ b/sbin/tingle
@@ -6,9 +6,10 @@ set -e
 
 usage() {
     cat - >&2 <<EOF
-Usage: tingle ACTION
+Usage: tingle ACTION ARG
 
-       Valid actions include check, warm, apply, and reboot.
+       Valid actions include check, warm, apply, and reboot. ARG is only
+       used by the reboot action.
 
        See tingle(8).
 EOF
@@ -29,11 +30,12 @@ updates_pending() {
     fi
 }
 
-if [ $# -ne 1 -o "$1" = "-h" -o "$1" = "--help" ]; then
+if [ $# -gt 2 -o "$1" = "-h" -o "$1" = "--help" ]; then
     usage
 fi
 
 action=$1
+arg=$2
 
 case $action in
     check)
@@ -58,7 +60,7 @@ case $action in
         if updates_pending >/dev/null ; then
             ${TINGLE_PREFIX}/lib/tingle/warm-cache
             ${TINGLE_PREFIX}/lib/tingle/apply-updates
-            ${TINGLE_PREFIX}/lib/tingle/reboot
+            ${TINGLE_PREFIX}/lib/tingle/reboot $arg
         fi
     ;;
     *)

--- a/share/man/man8/tingle-reboot.8
+++ b/share/man/man8/tingle-reboot.8
@@ -10,7 +10,7 @@
 Part of the tingle(8) suite\.
 .
 .SH "SYNOPSIS"
-\fBtingle\fR \fBreboot\fR
+\fBtingle\fR \fBreboot\fR \fB[min]\fR
 .
 .SH "DESCRIPTION"
 Rebooting a system is still the simplest and most reliable means of loading modified kernel and shared object code into memory\. (But see http://www\.ksplice\.com/ for a promising take on the kernel problem\.)
@@ -34,6 +34,11 @@ The following hook scripts, if they exist, will be executed when appropriate:
 .
 .P
 Execution order will correspond to the lexical sort order of script file names\. The first hook script failure will trigger an immediate abort\.
+.
+.P
+You can supply an optional argument \fBmin\fR, which is the number of minutes to
+wait until a reboot\. If not supplied it defaults to 10 minutes\.
+
 .
 .SH "RETURN VALUES"
 Returns non\-zero if something broke\.

--- a/share/man/man8/tingle.8
+++ b/share/man/man8/tingle.8
@@ -7,7 +7,7 @@
 \fBtingle\fR \- (n): a thin patch
 .
 .SH "SYNOPSIS"
-\fBtingle\fR \fBcheck\fR | \fBwarm\fR | \fBapply\fR | \fBreboot\fR
+\fBtingle\fR \fBcheck\fR | \fBwarm\fR | \fBapply\fR | \fBreboot\fR \fB[min]\fR
 .
 .SH "DESCRIPTION"
 tingle is a tool for applying packaged software updates\. It works by wrapping a thin shell program around your operating system\'s native package manager\. Pesky differences between package management implementations are abstracted away to simplify patch procedure\.


### PR DESCRIPTION
Rather than forcing a wait of ten minutes to reboot, this change means you can specify how long to wait when you call tingle. For example for a 2 minute wait for reboot, you would call:
 tingle reboot 2

It's the icing on the cake I need to use tingle in my environment.
