### PR TITLE
Have tingle follow symlinks to hook scripts

### DIFF
--- a/lib/tingle/common
+++ b/lib/tingle/common
@@ -115,7 +115,7 @@ execd() {
         warning "$d is not a valid hook scripts directory"
     else
         debug "Scanning $d for hook scripts"
-        find "${d}" -mindepth 1 -maxdepth 1 -type f | while read i; do
+        find -L "${d}" -mindepth 1 -maxdepth 1 -type f | while read i; do
             if [ -x "$i" ]; then
                 debug "Executing $i"
                 if ! is_interactive ; then


### PR DESCRIPTION
Tingle currently only checks for regular files.

It would be convenient to place symlinks into the hooks directories to
standard utility scripts rather than copying their entire contents into
place.